### PR TITLE
Fix header height and make it sticky on scroll

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 function Header() {
   return (
     <>
-      <div className="bg-primary h-16 w-full flex items-center">
+      <div className="bg-primary h-12 w-full flex items-center sticky top-0 z-50">
         <p className="text-2xl text-white pl-4">
           ポケスリ個体値比較
         </p>


### PR DESCRIPTION
- Reduce header height from h-16 (64px) to h-12 (48px)
- Add sticky positioning to keep header fixed during scrolling
- Add z-50 to ensure header stays on top of other elements

Resolves #16