### PR TITLE
Fix #60: Unify Pokemon selection width with other filter elements

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -158,7 +158,7 @@ function Search() {
       <div className="px-4 py-4 max-w-md md:max-w-4xl lg:max-w-5xl mx-auto">
         <div>
           {/* ポケモン選択 */}
-          <div className="w-full mx-auto">
+          <div className="w-full max-w-md mx-auto">
             <div className="flex items-center justify-between mb-2">
               <h2 className="text-base">ポケモン</h2>
             </div>


### PR DESCRIPTION
Adjusted the Pokemon selection list width to match sub-skill and nature selection components by adding max-w-md class. This ensures consistent visual alignment on desktop displays.

Changes:
- Added max-w-md to Pokemon selection wrapper div in Search.tsx:161
- Now matches the 448px (28rem) max-width used by SubSkillSelect and NatureSelector

🤖 Generated with [Claude Code](https://claude.com/claude-code)