### PR TITLE
Fix #57: おてスピ系スキルが反映されない問題を修正

### DIFF
--- a/src/utils/pokemonCalculator.ts
+++ b/src/utils/pokemonCalculator.ts
@@ -395,24 +395,36 @@ export const countSubSkills = (
 
   for (const subSkill of subSkills) {
     switch (subSkill.baseId) {
+      // おてつだいスピードM (variantベースとnameベースの両方をサポート)
+      case "supportSpeedM":
       case "helping_speed_m":
         counts.helpingSpeedM++;
         break;
+      // おてつだいスピードS (variantベースとnameベースの両方をサポート)
+      case "supportSpeedS":
       case "helping_speed_s":
         counts.helpingSpeedS++;
         break;
       case "helping_bonus":
         counts.helpingBonus++;
         break;
+      // 食材確率アップM (variantベースとnameベースの両方をサポート)
+      case "ingredientFinderM":
       case "ingredient_finder_m":
         counts.ingredientFinderM++;
         break;
+      // 食材確率アップS (variantベースとnameベースの両方をサポート)
+      case "ingredientFinderS":
       case "ingredient_finder_s":
         counts.ingredientFinderS++;
         break;
+      // スキル確率アップM (variantベースとnameベースの両方をサポート)
+      case "skillTriggerM":
       case "skill_trigger_m":
         counts.skillTriggerM++;
         break;
+      // スキル確率アップS (variantベースとnameベースの両方をサポート)
+      case "skillTriggerS":
       case "skill_trigger_s":
         counts.skillTriggerS++;
         break;


### PR DESCRIPTION
サブスキル選択UIではvariantベースのbaseId（例: supportSpeedM）が生成されるが、 countSubSkills関数ではnameベースのbaseId（例: helping_speed_m）のみを認識していたため、 おてつだいスピード、スキル確率アップ、食材確率アップなどのスキルが正しくカウントされていなかった。

変更内容:
- countSubSkills関数を修正して、variantベースとnameベースの両方のbaseIdを認識するように変更
- 影響するスキル: おてつだいスピードM/S、スキル確率アップM/S、食材確率アップM/S

計算ロジックの仕様確認:
- すべての計算式（おてつだい回数、食材回数、スキル回数、きのみ回数、きのみエナジー）は仕様と一致していることを確認済み