### PR TITLE
Fix #66: 計算結果の小数点第1位を正しく表示

### DIFF
--- a/src/utils/pokemonCalculator.ts
+++ b/src/utils/pokemonCalculator.ts
@@ -213,7 +213,7 @@ export const calculateFoodHelpsPerDay = (
   helpsPerDay: number,
   calculatedFoodDropRate: number
 ): number => {
-  return Math.floor(helpsPerDay * calculatedFoodDropRate);
+  return helpsPerDay * calculatedFoodDropRate;
 };
 
 /**
@@ -250,7 +250,7 @@ export const calculateSkillTriggersPerDay = (
   helpsPerDay: number,
   calculatedSkillRate: number
 ): number => {
-  return Math.floor(helpsPerDay * calculatedSkillRate);
+  return helpsPerDay * calculatedSkillRate;
 };
 
 /**
@@ -261,9 +261,7 @@ export const calculateBerryHelpsPerDay = (
   helpsPerDay: number,
   calculatedFoodDropRate: number
 ): number => {
-  return Math.floor(
-    helpsPerDay * (1 - calculatedFoodDropRate)
-  );
+  return helpsPerDay * (1 - calculatedFoodDropRate);
 };
 
 /**


### PR DESCRIPTION
食材/日、スキル/日、きのみ/日の計算結果から Math.floor を削除し、
小数点以下の値を保持するように修正。これにより、表示時に toFixed(1)
で小数点第1位が正しく表示されるようになる。