### PR TITLE
Fix #44: 全組み合わせランキングタブの実装

### DIFF
--- a/src/components/CombinationRanking.tsx
+++ b/src/components/CombinationRanking.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import { Pokemon } from "@/types/pokemon";
+import { SelectedSubSkill } from "@/types/selectedSubSkill";
+import { Button } from "@/components/ui/button";
+import { ArrowUp, Target } from "lucide-react";
+import { useVirtualScroll } from "@/hooks/useVirtualScroll";
+import {
+  generateRankingData,
+  findMyRank,
+  RankingEntry,
+} from "@/utils/rankingGenerator";
+import { getRarityStyles } from "@/utils/subSkillUtils";
+
+type RankingType = "skill" | "ingredient" | "berry";
+
+interface CombinationRankingProps {
+  pokemon: Pokemon;
+  currentNature?: string;
+  currentSubSkills: SelectedSubSkill[];
+}
+
+export default function CombinationRanking({
+  pokemon,
+  currentNature,
+  currentSubSkills,
+}: CombinationRankingProps) {
+  const [activeRankingType, setActiveRankingType] =
+    useState<RankingType>("skill");
+  const [isGenerating, setIsGenerating] = useState(true);
+
+  // Generate ranking data (memoized)
+  const rankingData = useMemo(() => {
+    setIsGenerating(true);
+    const startTime = performance.now();
+    const data = generateRankingData(pokemon);
+    const endTime = performance.now();
+    console.log(`Ranking generation time: ${endTime - startTime}ms`);
+    setIsGenerating(false);
+    return data;
+  }, [pokemon]);
+
+  // Get current ranking based on active tab
+  const currentRanking = useMemo(() => {
+    switch (activeRankingType) {
+      case "skill":
+        return rankingData.skillRanking;
+      case "ingredient":
+        return rankingData.ingredientRanking;
+      case "berry":
+        return rankingData.berryRanking;
+    }
+  }, [activeRankingType, rankingData]);
+
+  // Find current user's rank
+  const myRankIndex = useMemo(() => {
+    return findMyRank(currentRanking, currentNature, currentSubSkills);
+  }, [currentRanking, currentNature, currentSubSkills]);
+
+  // Virtual scroll settings
+  const ITEM_HEIGHT = 80; // Height of each ranking entry in pixels
+  const CONTAINER_HEIGHT = 600; // Height of the scrollable container
+
+  const virtualScroll = useVirtualScroll({
+    totalItems: currentRanking.length,
+    itemHeight: ITEM_HEIGHT,
+    containerHeight: CONTAINER_HEIGHT,
+    overscan: 5,
+  });
+
+  // Calculate visible range
+  const visibleStartRank = virtualScroll.startIndex + 1;
+  const visibleEndRank = Math.min(
+    virtualScroll.endIndex + 1,
+    currentRanking.length
+  );
+
+  // Get score label based on ranking type
+  const getScoreLabel = (type: RankingType): string => {
+    switch (type) {
+      case "skill":
+        return "スキル回数/日";
+      case "ingredient":
+        return "食材回数/日";
+      case "berry":
+        return "きのみエナジー/日";
+    }
+  };
+
+  // Get score value from entry
+  const getScore = (entry: RankingEntry, type: RankingType): number => {
+    switch (type) {
+      case "skill":
+        return entry.skillScore;
+      case "ingredient":
+        return entry.ingredientScore;
+      case "berry":
+        return entry.berryScore;
+    }
+  };
+
+  // Format score for display
+  const formatScore = (score: number): string => {
+    return score.toFixed(1);
+  };
+
+  const rankingTabs = [
+    { id: "skill" as const, label: "スキル" },
+    { id: "ingredient" as const, label: "食材" },
+    { id: "berry" as const, label: "きのみ" },
+  ];
+
+  if (isGenerating) {
+    return (
+      <div className="text-center py-12">
+        <div className="animate-pulse">
+          <p className="text-sm text-gray-600">ランキングを生成中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      {/* Sub-tabs for ranking type */}
+      <div className="flex border-b border-gray-300 mb-4">
+        {rankingTabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveRankingType(tab.id)}
+            className={`
+              flex-1 px-3 py-2 text-xs md:text-sm font-medium transition-colors
+              ${
+                activeRankingType === tab.id
+                  ? "border-b-2 border-cyan-500 text-cyan-600 bg-cyan-50"
+                  : "text-gray-600 hover:text-gray-800 hover:bg-gray-50"
+              }
+            `}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Navigation buttons */}
+      <div className="flex gap-2 mb-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => virtualScroll.scrollToIndex(0)}
+          className="flex items-center gap-1 text-xs"
+        >
+          <ArrowUp className="h-3 w-3" />
+          トップへ
+        </Button>
+        {myRankIndex !== null && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => virtualScroll.scrollToIndex(myRankIndex)}
+            className="flex items-center gap-1 text-xs"
+          >
+            <Target className="h-3 w-3" />
+            自分のランク ({myRankIndex + 1}位)
+          </Button>
+        )}
+      </div>
+
+      {/* Display range indicator */}
+      <div className="text-xs text-gray-600 mb-2">
+        表示: {visibleStartRank}-{visibleEndRank} / 全{currentRanking.length}
+        件
+      </div>
+
+      {/* Virtual scrolling container */}
+      <div
+        ref={virtualScroll.containerRef}
+        className="border border-gray-300 rounded-lg overflow-y-auto relative"
+        style={{ height: `${CONTAINER_HEIGHT}px` }}
+      >
+        {/* Spacer for total height */}
+        <div style={{ height: `${virtualScroll.totalHeight}px` }}>
+          {/* Visible items container */}
+          <div
+            style={{
+              transform: `translateY(${virtualScroll.offsetY}px)`,
+            }}
+          >
+            {virtualScroll.visibleItems.map((index) => {
+              const entry = currentRanking[index];
+              const isMyRank = index === myRankIndex;
+              const score = getScore(entry, activeRankingType);
+
+              return (
+                <div
+                  key={index}
+                  className={`
+                    border-b border-gray-200 p-3
+                    ${isMyRank ? "bg-yellow-50 border-l-4 border-l-yellow-500" : ""}
+                  `}
+                  style={{ height: `${ITEM_HEIGHT}px` }}
+                >
+                  <div className="flex items-center gap-3 h-full">
+                    {/* Rank number */}
+                    <div
+                      className={`
+                        flex-shrink-0 w-12 h-12 rounded-full flex items-center justify-center font-bold text-sm
+                        ${
+                          entry.rank === 1
+                            ? "bg-yellow-400 text-yellow-900"
+                            : entry.rank === 2
+                            ? "bg-gray-300 text-gray-800"
+                            : entry.rank === 3
+                            ? "bg-amber-600 text-white"
+                            : "bg-gray-100 text-gray-700"
+                        }
+                      `}
+                    >
+                      {entry.rank}
+                    </div>
+
+                    {/* Details */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-sm font-medium text-gray-800">
+                          {entry.natureDisplay}
+                        </span>
+                        {isMyRank && (
+                          <span className="text-xs px-2 py-0.5 bg-yellow-500 text-white rounded-full font-medium">
+                            現在
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex flex-wrap gap-1">
+                        {entry.subSkills.length === 0 ? (
+                          <span className="text-xs text-gray-500 italic">
+                            サブスキルなし
+                          </span>
+                        ) : (
+                          entry.subSkills.map((skill, idx) => {
+                            const rarityStyle = getRarityStyles(skill.rarity);
+                            return (
+                              <span
+                                key={idx}
+                                className={`text-xs px-2 py-0.5 rounded-md font-medium ${rarityStyle.chip}`}
+                              >
+                                {skill.name}
+                              </span>
+                            );
+                          })
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Score */}
+                    <div className="flex-shrink-0 text-right">
+                      <div className="text-lg font-bold text-gray-900">
+                        {formatScore(score)}
+                      </div>
+                      <div className="text-xs text-gray-600">
+                        {getScoreLabel(activeRankingType)}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Summary */}
+      <div className="mt-3 text-xs text-gray-600">
+        <p>
+          {pokemon.displayName}の全{currentRanking.length}
+          通りの組み合わせから、{getScoreLabel(activeRankingType)}
+          の降順でランキング表示しています。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -8,6 +8,7 @@ import NatureSelector from "./nature/NatureSelector";
 import CalculatedPokemonInfo from "./CalculatedPokemonInfo";
 import ResultTabs from "./ResultTabs";
 import HistoryList from "./HistoryList";
+import CombinationRanking from "./CombinationRanking";
 import { SelectedSubSkill } from "@/types/selectedSubSkill";
 import { SelectedNature } from "@/types/nature";
 import { pokemonData } from "@/data/pokemonData";
@@ -228,6 +229,19 @@ function Search() {
         {/* タブ切り替え（常に表示） */}
         <div className="mt-6">
           <ResultTabs
+            rankingContent={
+              selectedPokemon ? (
+                <CombinationRanking
+                  pokemon={selectedPokemon}
+                  currentNature={nature?.name}
+                  currentSubSkills={selectedSubSkills}
+                />
+              ) : (
+                <div className="text-center py-12 text-gray-500">
+                  <p className="text-sm">ポケモンを選択してください</p>
+                </div>
+              )
+            }
             historyContent={
               <HistoryList
                 history={history}

--- a/src/hooks/useVirtualScroll.ts
+++ b/src/hooks/useVirtualScroll.ts
@@ -1,0 +1,111 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export interface VirtualScrollOptions {
+  /** Total number of items */
+  totalItems: number;
+  /** Height of each item in pixels */
+  itemHeight: number;
+  /** Height of the viewport/container in pixels */
+  containerHeight: number;
+  /** Number of items to render above/below visible area (buffer) */
+  overscan?: number;
+}
+
+export interface VirtualScrollResult {
+  /** Index of first visible item */
+  startIndex: number;
+  /** Index of last visible item */
+  endIndex: number;
+  /** Items currently visible (with overscan) */
+  visibleItems: number[];
+  /** Total height of the scrollable content */
+  totalHeight: number;
+  /** Offset for positioning visible items */
+  offsetY: number;
+  /** Ref to attach to scrollable container */
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  /** Scroll to specific index */
+  scrollToIndex: (index: number) => void;
+  /** Current scroll position */
+  scrollTop: number;
+}
+
+/**
+ * Custom hook for virtual scrolling implementation
+ * Optimizes rendering of large lists by only rendering visible items
+ */
+export function useVirtualScroll({
+  totalItems,
+  itemHeight,
+  containerHeight,
+  overscan = 3,
+}: VirtualScrollOptions): VirtualScrollResult {
+  const [scrollTop, setScrollTop] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Calculate total height
+  const totalHeight = totalItems * itemHeight;
+
+  // Calculate visible range
+  const startIndex = Math.max(
+    0,
+    Math.floor(scrollTop / itemHeight) - overscan
+  );
+  const endIndex = Math.min(
+    totalItems - 1,
+    Math.ceil((scrollTop + containerHeight) / itemHeight) + overscan
+  );
+
+  // Generate array of visible item indices
+  const visibleItems = [];
+  for (let i = startIndex; i <= endIndex; i++) {
+    visibleItems.push(i);
+  }
+
+  // Calculate offset for positioning
+  const offsetY = startIndex * itemHeight;
+
+  // Handle scroll event
+  const handleScroll = useCallback(() => {
+    if (containerRef.current) {
+      setScrollTop(containerRef.current.scrollTop);
+    }
+  }, []);
+
+  // Scroll to specific index
+  const scrollToIndex = useCallback(
+    (index: number) => {
+      if (containerRef.current) {
+        const targetScrollTop = Math.max(
+          0,
+          Math.min(index * itemHeight, totalHeight - containerHeight)
+        );
+        containerRef.current.scrollTop = targetScrollTop;
+        setScrollTop(targetScrollTop);
+      }
+    },
+    [itemHeight, totalHeight, containerHeight]
+  );
+
+  // Attach scroll listener
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container) {
+      container.addEventListener("scroll", handleScroll, { passive: true });
+      return () => {
+        container.removeEventListener("scroll", handleScroll);
+      };
+    }
+  }, [handleScroll]);
+
+  return {
+    startIndex,
+    endIndex,
+    visibleItems,
+    totalHeight,
+    offsetY,
+    containerRef,
+    scrollToIndex,
+    scrollTop,
+  };
+}

--- a/src/utils/rankingGenerator.ts
+++ b/src/utils/rankingGenerator.ts
@@ -1,0 +1,201 @@
+import { Pokemon } from "@/types/pokemon";
+import { SelectedSubSkill } from "@/types/selectedSubSkill";
+import { calculatePokemonStatsSimple } from "./pokemonCalculator";
+import { NATURE_GROUPS } from "@/data/natureData";
+import { subSkillData } from "@/data/subSkillData";
+
+/**
+ * Ranking entry for a specific combination
+ */
+export interface RankingEntry {
+  /** Ranking position (1-based) */
+  rank: number;
+  /** Nature name */
+  natureName: string;
+  /** Display string for nature */
+  natureDisplay: string;
+  /** Sub-skills in this combination */
+  subSkills: SelectedSubSkill[];
+  /** Skill triggers per day */
+  skillScore: number;
+  /** Ingredient helps per day */
+  ingredientScore: number;
+  /** Berry energy per day */
+  berryScore: number;
+}
+
+/**
+ * Sub-skills that affect calculations
+ */
+const CALCULATION_AFFECTING_SKILLS = [
+  "helping_speed_m",
+  "helping_speed_s",
+  "helping_bonus",
+  "ingredient_finder_m",
+  "ingredient_finder_s",
+  "skill_trigger_m",
+  "skill_trigger_s",
+];
+
+/**
+ * Generate all sub-skill combinations (0 to 3 skills)
+ * Only includes skills that affect calculations
+ */
+function generateSubSkillCombinations(): SelectedSubSkill[][] {
+  const relevantSkills = subSkillData.filter((skill) =>
+    CALCULATION_AFFECTING_SKILLS.includes(skill.name)
+  );
+
+  const combinations: SelectedSubSkill[][] = [];
+
+  // Empty combination (no sub-skills)
+  combinations.push([]);
+
+  // Generate combinations of 1, 2, and 3 skills
+  for (let count = 1; count <= 3; count++) {
+    const combos = generateCombinations(relevantSkills, count);
+    combinations.push(...combos);
+  }
+
+  return combinations;
+}
+
+/**
+ * Helper function to generate combinations of specific size
+ */
+function generateCombinations(
+  skills: typeof subSkillData,
+  size: number
+): SelectedSubSkill[][] {
+  const results: SelectedSubSkill[][] = [];
+
+  function backtrack(start: number, current: SelectedSubSkill[]) {
+    if (current.length === size) {
+      results.push([...current]);
+      return;
+    }
+
+    for (let i = start; i < skills.length; i++) {
+      const skill = skills[i];
+      const level = current.length === 0 ? 10 : current.length === 1 ? 25 : 50;
+
+      const selectedSkill: SelectedSubSkill = {
+        id: `${skill.name}_${level}_${Date.now()}_${Math.random()}`,
+        baseId: skill.name,
+        name: skill.displayName,
+        variant: null,
+        level: level,
+        rarity: skill.rarity,
+      };
+
+      current.push(selectedSkill);
+      backtrack(i + 1, current);
+      current.pop();
+    }
+  }
+
+  backtrack(0, []);
+  return results;
+}
+
+/**
+ * Generate ranking data for all nature and sub-skill combinations
+ */
+export function generateRankingData(
+  pokemon: Pokemon
+): {
+  skillRanking: RankingEntry[];
+  ingredientRanking: RankingEntry[];
+  berryRanking: RankingEntry[];
+} {
+  const allCombinations: RankingEntry[] = [];
+
+  // Get all natures
+  const allNatures = NATURE_GROUPS.flatMap((group) => group.natures);
+
+  // Get all sub-skill combinations
+  const subSkillCombinations = generateSubSkillCombinations();
+
+  // Calculate score for each combination
+  for (const nature of allNatures) {
+    for (const subSkills of subSkillCombinations) {
+      const result = calculatePokemonStatsSimple(
+        pokemon,
+        60,
+        nature.name,
+        subSkills
+      );
+
+      const natureDisplay = nature.up
+        ? `${nature.name} (▲${nature.up} ▼${nature.down})`
+        : `${nature.name} (補正なし)`;
+
+      allCombinations.push({
+        rank: 0, // Will be set after sorting
+        natureName: nature.name,
+        natureDisplay,
+        subSkills: [...subSkills],
+        skillScore: result.skillTriggersPerDay,
+        ingredientScore: result.foodHelpsPerDay,
+        berryScore: result.berryEnergyPerDay,
+      });
+    }
+  }
+
+  // Sort by skill score (descending) and assign ranks
+  const skillRanking = [...allCombinations].sort(
+    (a, b) => b.skillScore - a.skillScore
+  );
+  skillRanking.forEach((entry, index) => {
+    entry.rank = index + 1;
+  });
+
+  // Sort by ingredient score (descending) and assign ranks
+  const ingredientRanking = [...allCombinations].sort(
+    (a, b) => b.ingredientScore - a.ingredientScore
+  );
+  ingredientRanking.forEach((entry, index) => {
+    entry.rank = index + 1;
+  });
+
+  // Sort by berry score (descending) and assign ranks
+  const berryRanking = [...allCombinations].sort(
+    (a, b) => b.berryScore - a.berryScore
+  );
+  berryRanking.forEach((entry, index) => {
+    entry.rank = index + 1;
+  });
+
+  return {
+    skillRanking,
+    ingredientRanking,
+    berryRanking,
+  };
+}
+
+/**
+ * Find the rank of a specific combination in the ranking
+ */
+export function findMyRank(
+  ranking: RankingEntry[],
+  natureName: string | undefined,
+  subSkills: SelectedSubSkill[]
+): number | null {
+  if (!natureName) return null;
+
+  // Normalize sub-skills for comparison
+  const normalizedSubSkills = subSkills
+    .map((s) => s.baseId)
+    .sort()
+    .join(",");
+
+  const index = ranking.findIndex((entry) => {
+    const entrySubSkills = entry.subSkills
+      .map((s) => s.baseId)
+      .sort()
+      .join(",");
+    return entry.natureName === natureName && entrySubSkills === normalizedSubSkills;
+  });
+
+  return index >= 0 ? index : null;
+}


### PR DESCRIPTION
- 仮想スクロール用カスタムフック (useVirtualScroll) を実装
- ランキングデータ生成ユーティリティを実装
  - 性格とサブスキルの全組み合わせを生成
  - スキル/食材/きのみの各メトリックでランキング計算
- CombinationRankingコンポーネントを実装
  - 3つのサブタブ（スキル、食材、きのみ）
  - 仮想スクロールによる効率的な大量データ表示
  - 「トップへジャンプ」ボタン
  - 「自分のランクへジャンプ」ボタン
  - 表示範囲インジケーター
  - 現在の組み合わせのハイライト表示
- Search.tsxに統合し、ランキングタブで表示