### PR TITLE
Fix #71: ランキング順位バグ修正

### DIFF
--- a/src/utils/rankingGenerator.ts
+++ b/src/utils/rankingGenerator.ts
@@ -143,28 +143,31 @@ export function generateRankingData(
   }
 
   // Sort by skill score (descending) and assign ranks
-  const skillRanking = [...allCombinations].sort(
-    (a, b) => b.skillScore - a.skillScore
-  );
-  skillRanking.forEach((entry, index) => {
-    entry.rank = index + 1;
-  });
+  const skillRanking = [...allCombinations]
+    .sort((a, b) => b.skillScore - a.skillScore)
+    .map((entry, index) => ({
+      ...entry,
+      rank: index + 1,
+      subSkills: [...entry.subSkills],
+    }));
 
   // Sort by ingredient score (descending) and assign ranks
-  const ingredientRanking = [...allCombinations].sort(
-    (a, b) => b.ingredientScore - a.ingredientScore
-  );
-  ingredientRanking.forEach((entry, index) => {
-    entry.rank = index + 1;
-  });
+  const ingredientRanking = [...allCombinations]
+    .sort((a, b) => b.ingredientScore - a.ingredientScore)
+    .map((entry, index) => ({
+      ...entry,
+      rank: index + 1,
+      subSkills: [...entry.subSkills],
+    }));
 
   // Sort by berry score (descending) and assign ranks
-  const berryRanking = [...allCombinations].sort(
-    (a, b) => b.berryScore - a.berryScore
-  );
-  berryRanking.forEach((entry, index) => {
-    entry.rank = index + 1;
-  });
+  const berryRanking = [...allCombinations]
+    .sort((a, b) => b.berryScore - a.berryScore)
+    .map((entry, index) => ({
+      ...entry,
+      rank: index + 1,
+      subSkills: [...entry.subSkills],
+    }));
 
   return {
     skillRanking,


### PR DESCRIPTION
各サブタブ（食材/スキル/きのみ）で独立したランキングデータを管理するように修正。
以前は浅いコピーにより同じオブジェクトを共有していたため、
最後に設定されたランク（きのみ）がすべてのタブに反映されていた。

変更内容:
- 各ランキング生成時にオブジェクトのディープコピーを作成
- 各タブで独立したrank値を保持