### PR TITLE
Fix #77: 組み合わせランキングの性格修正情報を全デバイスで表示

### DIFF
--- a/src/components/CombinationRanking.tsx
+++ b/src/components/CombinationRanking.tsx
@@ -258,8 +258,7 @@ export default function CombinationRanking({
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-1 md:gap-2 mb-1">
                         <span className="text-xs md:text-sm font-medium text-gray-800 truncate">
-                          <span className="hidden md:inline">{entry.natureDisplay}</span>
-                          <span className="md:hidden">{entry.natureName}</span>
+                          {entry.natureDisplay}
                         </span>
                         {isMyRank && (
                           <span className="text-xs px-1.5 md:px-2 py-0.5 bg-yellow-500 text-white rounded-full font-medium flex-shrink-0">


### PR DESCRIPTION
モバイルとデスクトップの両方で性格の修正情報（▲と▼の記号付き）を
表示するように変更。以前はモバイルでは性格名のみが表示されていたが、
今回の変更により全デバイスで「性格名 (▲上昇ステータス ▼下降ステータス)」
の形式で表示されるようになった。