### PR TITLE
Fix #79: 個体値分析コンポーネント実装

### DIFF
--- a/src/components/CombinationRanking.tsx
+++ b/src/components/CombinationRanking.tsx
@@ -13,6 +13,7 @@ import {
   RankingEntry,
 } from "@/utils/rankingGenerator";
 import { getRarityStyles } from "@/utils/subSkillUtils";
+import IVAnalysisComponent from "./IVAnalysisComponent";
 
 type RankingType = "skill" | "ingredient" | "berry";
 
@@ -63,31 +64,68 @@ export default function CombinationRanking({
     return data;
   }, [pokemon]);
 
-  // Get current ranking based on active tab
-  const currentRanking = useMemo(() => {
-    let ranking: RankingEntry[];
-    switch (activeRankingType) {
-      case "skill":
-        ranking = rankingData.skillRanking;
-        break;
-      case "ingredient":
-        ranking = rankingData.ingredientRanking;
-        break;
-      case "berry":
-        ranking = rankingData.berryRanking;
-        break;
-    }
-    // Ensure user's current combination is in the ranking
+  // Ensure user's current combination is in each ranking
+  const skillRankingWithUser = useMemo(() => {
     return ensureUserRankInRanking(
-      ranking,
+      rankingData.skillRanking,
       pokemon,
       currentNature,
       currentSubSkills,
-      activeRankingType
+      "skill"
     );
-  }, [activeRankingType, rankingData, pokemon, currentNature, currentSubSkills]);
+  }, [rankingData.skillRanking, pokemon, currentNature, currentSubSkills]);
 
-  // Find current user's rank
+  const ingredientRankingWithUser = useMemo(() => {
+    return ensureUserRankInRanking(
+      rankingData.ingredientRanking,
+      pokemon,
+      currentNature,
+      currentSubSkills,
+      "ingredient"
+    );
+  }, [rankingData.ingredientRanking, pokemon, currentNature, currentSubSkills]);
+
+  const berryRankingWithUser = useMemo(() => {
+    return ensureUserRankInRanking(
+      rankingData.berryRanking,
+      pokemon,
+      currentNature,
+      currentSubSkills,
+      "berry"
+    );
+  }, [rankingData.berryRanking, pokemon, currentNature, currentSubSkills]);
+
+  // Get current ranking based on active tab
+  const currentRanking = useMemo(() => {
+    switch (activeRankingType) {
+      case "skill":
+        return skillRankingWithUser;
+      case "ingredient":
+        return ingredientRankingWithUser;
+      case "berry":
+        return berryRankingWithUser;
+    }
+  }, [
+    activeRankingType,
+    skillRankingWithUser,
+    ingredientRankingWithUser,
+    berryRankingWithUser,
+  ]);
+
+  // Find current user's rank for each ranking type
+  const mySkillRank = useMemo(() => {
+    return findMyRank(skillRankingWithUser, currentNature, currentSubSkills);
+  }, [skillRankingWithUser, currentNature, currentSubSkills]);
+
+  const myIngredientRank = useMemo(() => {
+    return findMyRank(ingredientRankingWithUser, currentNature, currentSubSkills);
+  }, [ingredientRankingWithUser, currentNature, currentSubSkills]);
+
+  const myBerryRank = useMemo(() => {
+    return findMyRank(berryRankingWithUser, currentNature, currentSubSkills);
+  }, [berryRankingWithUser, currentNature, currentSubSkills]);
+
+  // Find current user's rank for active ranking type
   const myRankIndex = useMemo(() => {
     return findMyRank(currentRanking, currentNature, currentSubSkills);
   }, [currentRanking, currentNature, currentSubSkills]);
@@ -157,6 +195,18 @@ export default function CombinationRanking({
 
   return (
     <div className="w-full">
+      {/* IV Analysis Component */}
+      <IVAnalysisComponent
+        pokemon={pokemon}
+        skillRanking={skillRankingWithUser}
+        ingredientRanking={ingredientRankingWithUser}
+        berryRanking={berryRankingWithUser}
+        mySkillRank={mySkillRank}
+        myIngredientRank={myIngredientRank}
+        myBerryRank={myBerryRank}
+        onRankingTypeChange={setActiveRankingType}
+      />
+
       {/* Sub-tabs for ranking type */}
       <div className="flex border-b border-gray-300 mb-4">
         {rankingTabs.map((tab) => (

--- a/src/components/IVAnalysisComponent.tsx
+++ b/src/components/IVAnalysisComponent.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Pokemon } from "@/types/pokemon";
+import { RankingEntry } from "@/utils/rankingGenerator";
+
+type RankingType = "skill" | "ingredient" | "berry";
+
+interface IVAnalysisComponentProps {
+  pokemon: Pokemon;
+  skillRanking: RankingEntry[];
+  ingredientRanking: RankingEntry[];
+  berryRanking: RankingEntry[];
+  mySkillRank: number | null;
+  myIngredientRank: number | null;
+  myBerryRank: number | null;
+  onRankingTypeChange: (type: RankingType) => void;
+}
+
+export default function IVAnalysisComponent({
+  pokemon,
+  skillRanking,
+  ingredientRanking,
+  berryRanking,
+  mySkillRank,
+  myIngredientRank,
+  myBerryRank,
+  onRankingTypeChange,
+}: IVAnalysisComponentProps) {
+  // ランキングとパーセンテージを計算
+  const getRankDisplay = (rank: number | null, total: number) => {
+    if (rank === null) return { rankText: "-", percentText: "-" };
+    const actualRank = rank + 1; // 0-indexed to 1-indexed
+    const percentage = ((actualRank / total) * 100).toFixed(1);
+    return {
+      rankText: `${actualRank}位`,
+      percentText: `上位${percentage}%`,
+    };
+  };
+
+  const skillRankDisplay = getRankDisplay(mySkillRank, skillRanking.length);
+  const ingredientRankDisplay = getRankDisplay(
+    myIngredientRank,
+    ingredientRanking.length
+  );
+  const berryRankDisplay = getRankDisplay(myBerryRank, berryRanking.length);
+
+  // スコアを取得
+  const getScore = (
+    ranking: RankingEntry[],
+    myRank: number | null
+  ): string => {
+    if (myRank === null) return "-";
+    return ranking[myRank]?.skillScore?.toFixed(1) || "-";
+  };
+
+  const getIngredientScore = (
+    ranking: RankingEntry[],
+    myRank: number | null
+  ): string => {
+    if (myRank === null) return "-";
+    return ranking[myRank]?.ingredientScore?.toFixed(1) || "-";
+  };
+
+  const getBerryScore = (
+    ranking: RankingEntry[],
+    myRank: number | null
+  ): string => {
+    if (myRank === null) return "-";
+    return ranking[myRank]?.berryScore?.toFixed(1) || "-";
+  };
+
+  const skillScore = getScore(skillRanking, mySkillRank);
+  const ingredientScore = getIngredientScore(
+    ingredientRanking,
+    myIngredientRank
+  );
+  const berryScore = getBerryScore(berryRanking, myBerryRank);
+
+  // テーブル行のデータ
+  const tableRows = [
+    {
+      type: "ingredient" as RankingType,
+      label: "食材回数",
+      score: ingredientScore,
+      rank: ingredientRankDisplay.rankText,
+      percent: ingredientRankDisplay.percentText,
+    },
+    {
+      type: "skill" as RankingType,
+      label: "スキル回数",
+      score: skillScore,
+      rank: skillRankDisplay.rankText,
+      percent: skillRankDisplay.percentText,
+    },
+    {
+      type: "berry" as RankingType,
+      label: "きのみエナジー",
+      score: berryScore,
+      rank: berryRankDisplay.rankText,
+      percent: berryRankDisplay.percentText,
+    },
+  ];
+
+  return (
+    <div className="mb-6 p-4 bg-gradient-to-r from-blue-50 to-cyan-50 rounded-lg border border-blue-200 shadow-sm">
+      <h3 className="text-sm md:text-base font-bold text-gray-800 mb-3">
+        {pokemon.displayName} の個体値分析
+      </h3>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs md:text-sm">
+          <thead>
+            <tr className="border-b-2 border-blue-300">
+              <th className="text-left py-2 px-2 md:px-3 font-semibold text-gray-700">
+                項目
+              </th>
+              <th className="text-right py-2 px-2 md:px-3 font-semibold text-gray-700">
+                値/日
+              </th>
+              <th className="text-center py-2 px-2 md:px-3 font-semibold text-gray-700">
+                順位
+              </th>
+              <th className="text-center py-2 px-2 md:px-3 font-semibold text-gray-700">
+                割合
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {tableRows.map((row) => (
+              <tr
+                key={row.type}
+                onClick={() => onRankingTypeChange(row.type)}
+                className="border-b border-blue-200 hover:bg-blue-100 cursor-pointer transition-colors"
+              >
+                <td className="py-2 px-2 md:px-3 font-medium text-gray-800">
+                  {row.label}
+                </td>
+                <td className="py-2 px-2 md:px-3 text-right font-semibold text-gray-900">
+                  {row.score}
+                </td>
+                <td className="py-2 px-2 md:px-3 text-center">
+                  <span className="inline-block px-2 py-1 bg-yellow-100 text-yellow-800 rounded-md font-bold text-xs md:text-sm">
+                    {row.rank}
+                  </span>
+                </td>
+                <td className="py-2 px-2 md:px-3 text-center text-gray-700">
+                  {row.percent}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-gray-600 mt-3">
+        クリックすると対応するランキングタブに切り替わります
+      </p>
+    </div>
+  );
+}

--- a/src/components/ResultTabs.tsx
+++ b/src/components/ResultTabs.tsx
@@ -2,32 +2,25 @@
 
 import React, { useState } from "react";
 
-type TabType = "analysis" | "ranking" | "history";
+type TabType = "ranking" | "history";
 
 interface ResultTabsProps {
   /** 初期表示タブ */
   defaultTab?: TabType;
 
   /** 各タブのコンテンツ */
-  analysisContent?: React.ReactNode;
   rankingContent?: React.ReactNode;
   historyContent: React.ReactNode;
 }
 
 export default function ResultTabs({
-  defaultTab = "history",
-  analysisContent,
+  defaultTab = "ranking",
   rankingContent,
   historyContent,
 }: ResultTabsProps) {
   const [activeTab, setActiveTab] = useState<TabType>(defaultTab);
 
   const tabs = [
-    {
-      id: "analysis" as const,
-      label: "個体値分析",
-      content: analysisContent,
-    },
     {
       id: "ranking" as const,
       label: "組み合わせランキング",


### PR DESCRIPTION
- 個体値分析タブを削除し、組み合わせランキングタブに統合
- 新しいIVAnalysisComponentを作成し、選択ポケモンのランキング表示（順位、上位％）
- 食材、スキル、きのみの各指標を表形式で表示
- テーブル行をクリックすると対応するランキングタブに切り替わる機能を実装
- タブ数を3つから2つ（組み合わせランキング、評価履歴）に削減