### PR TITLE
Fix #80: アプリ起動時に最新の履歴を自動表示

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/PokeNameCombobox";
 import SubSkillSelect from "./SubSkillSelect";
@@ -153,6 +153,25 @@ function Search() {
     // 画面をトップにスクロール
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
+
+  // 初回ロード時に最新の履歴を自動反映
+  useEffect(() => {
+    if (!isLoading && history.length > 0 && !calculationResult) {
+      const latestHistory = history[0];
+
+      // 計算結果を復元
+      setCalculationResult(latestHistory.calculationResult);
+
+      // 表示用スナップショットを復元
+      setDisplaySnapshot({
+        pokemonName: latestHistory.pokemonName,
+        pokemonNumber: latestHistory.pokemonNumber,
+        pokemonType: latestHistory.pokemonType,
+        nature: latestHistory.natureDisplay,
+        subSkills: latestHistory.subSkills,
+      });
+    }
+  }, [isLoading, history, calculationResult]);
 
   return (
     <>


### PR DESCRIPTION
アプリ起動時に履歴データがある場合、最後に選択されたポケモンのランキング表示を
自動的に行う機能を実装。

変更内容:
- Search.tsx に useEffect を追加し、初回ロード時に最新の履歴から計算結果とスナップショットを復元
- ポケモン選択、サブスキル選択、性格選択のUIは空のまま維持
- 履歴がない場合や既に計算結果が表示されている場合は何もしない

これにより、アプリを再度開いた際に、前回の計算結果が即座に表示されるようになり、
ユーザーエクスペリエンスが向上します。