### PR TITLE
Fix #83: 個体値分析コンポで該当順位に自動スクロール

### DIFF
--- a/src/components/CombinationRanking.tsx
+++ b/src/components/CombinationRanking.tsx
@@ -183,6 +183,33 @@ export default function CombinationRanking({
     { id: "berry" as const, label: "きのみ" },
   ];
 
+  // Handle ranking type change with automatic scroll to user's rank
+  const handleRankingTypeChange = (type: RankingType) => {
+    setActiveRankingType(type);
+
+    // Get the corresponding rank index for the new ranking type
+    let targetRankIndex: number | null = null;
+    switch (type) {
+      case "skill":
+        targetRankIndex = mySkillRank;
+        break;
+      case "ingredient":
+        targetRankIndex = myIngredientRank;
+        break;
+      case "berry":
+        targetRankIndex = myBerryRank;
+        break;
+    }
+
+    // Scroll to the user's rank after state update
+    if (targetRankIndex !== null) {
+      // Use setTimeout to ensure state update and re-render complete first
+      setTimeout(() => {
+        virtualScroll.scrollToIndex(targetRankIndex);
+      }, 0);
+    }
+  };
+
   if (isGenerating) {
     return (
       <div className="text-center py-12">
@@ -204,7 +231,7 @@ export default function CombinationRanking({
         mySkillRank={mySkillRank}
         myIngredientRank={myIngredientRank}
         myBerryRank={myBerryRank}
-        onRankingTypeChange={setActiveRankingType}
+        onRankingTypeChange={handleRankingTypeChange}
       />
 
       {/* Sub-tabs for ranking type */}


### PR DESCRIPTION
個体値分析コンポーネントのランキング行（食材回数、スキル回数、きのみエナジー）をクリックした際に、
対応するランキングタブに切り替わると同時に、該当するポケモンの順位まで自動的にスクロールするように修正。

変更内容:
- handleRankingTypeChange関数を追加
- ランキングタイプ変更時に、該当する順位インデックスを取得
- setTimeoutを使用して状態更新後にscrollToIndexを実行
- 「自分のランク」ボタンと同じスクロール動作を実現