### PR TITLE
Fix #92: 性格選択UIデザインをサブスキルUIに統一

### DIFF
--- a/src/components/nature/NatureSelector.tsx
+++ b/src/components/nature/NatureSelector.tsx
@@ -97,8 +97,8 @@ export default function NatureSelector({
             w-full py-1.5 px-3 rounded-lg border-2 border-dashed
             flex items-center justify-center gap-1.5
             text-sm font-medium transition-all
-            border-secondary text-secondary bg-blue-50
-            hover:bg-blue-100 hover:border-slate-400 active:scale-95
+            border-secondary text-secondary bg-blue-50/30
+            hover:bg-blue-50 hover:border-slate-400 active:scale-95
           "
         >
           <Plus className="w-4 h-4" />


### PR DESCRIPTION
性格選択の未選択状態ボタンの背景色をサブスキル選択UIに合わせて修正。
- bg-blue-50 → bg-blue-50/30 (透明度30%)
- hover:bg-blue-100 → hover:bg-blue-50

これによりUIの視覚的な統一性が向上します。