### PR TITLE
Fix #89: モバイルでのランキング表示崩れを修正

### DIFF
--- a/src/components/CombinationRanking.tsx
+++ b/src/components/CombinationRanking.tsx
@@ -349,7 +349,8 @@ export default function CombinationRanking({
                             return (
                               <span
                                 key={idx}
-                                className={`text-xs px-1.5 md:px-2 py-0.5 rounded-md font-medium ${rarityStyle.chip}`}
+                                className={`inline-block text-xs px-1.5 md:px-2 py-0.5 rounded-md font-medium max-w-[120px] md:max-w-none truncate ${rarityStyle.chip}`}
+                                title={skill.name}
                               >
                                 {skill.name}
                               </span>


### PR DESCRIPTION
サブスキル名が長い場合（おてつだいボーナス、おてつだいスピードM等）、
モバイルビューで複数行に折り返されて表示が崩れる問題を修正。

変更内容:
- サブスキルチップにmax-width制限を追加（モバイル: 120px）
- テキストが長い場合は省略記号（...）で切り詰め
- ホバー時に完全な名前を表示するtitle属性を追加