### PR TITLE
Optimize Japanese font display with hybrid font stack

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -120,6 +120,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-geist-sans), "Hiragino Kaku Gothic ProN", "Hiragino Sans", "BIZ UDPGothic", Meiryo, sans-serif;
     transition: background-color 0.3s ease, color 0.3s ease;
   }
 


### PR DESCRIPTION
Implement Method C (Hybrid Font Stack) as proposed in issue #17 to
optimize Japanese font display while maintaining Geist for Latin
characters.

Changes:
- Add font-family property to body in app/globals.css
- Include fallback fonts optimized for Japanese (Hiragino, BIZ UDPGothic, Meiryo)
- Maintain Geist font for alphanumeric characters
- No additional font downloads (0KB performance impact)

Benefits:
- Consistent design with Geist for Latin characters
- Optimal rendering for Japanese text using OS-native fonts
- Cross-platform support (macOS, Windows, Android)

Fixes #17