### PR TITLE
Reorganize table layout to be more compact

### DIFF
--- a/src/components/CalculatedPokemonInfo.tsx
+++ b/src/components/CalculatedPokemonInfo.tsx
@@ -142,74 +142,67 @@ const CalculatedPokemonInfo: React.FC<
           <table className="w-full text-[10px] md:text-xs">
             <thead className="bg-muted/50">
               <tr>
-                <th className="px-2 md:px-3 py-2 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                <th className="px-2 md:px-3 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
                   お手伝い時間
                 </th>
-                <th className="px-2 md:px-3 py-2 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                <th className="px-2 md:px-3 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
                   食材
                 </th>
-                <th className="px-2 md:px-3 py-2 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                <th className="px-2 md:px-3 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
                   スキル
                 </th>
-                <th className="px-2 md:px-3 py-2 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                <th className="px-2 md:px-3 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
                   きのみ
                 </th>
               </tr>
             </thead>
             <tbody>
               <tr>
-                <td className="px-2 md:px-3 py-2 font-bold text-foreground whitespace-nowrap">
+                <td className="px-2 md:px-3 py-1.5 font-bold text-foreground whitespace-nowrap">
                   {calculationResult.calculatedSupportTime.toLocaleString()}
                   秒
                 </td>
-                <td className="px-2 md:px-3 py-2 whitespace-nowrap">
-                  <div className="flex flex-col gap-0.5">
-                    <div className="font-bold text-foreground">
+                <td className="px-2 md:px-3 py-1.5 whitespace-nowrap">
+                  <div className="font-bold text-orange-600 dark:text-orange-400">
+                    {calculationResult.foodHelpsPerDay.toFixed(1)}
+                    回/日{" "}
+                    <span className="text-foreground">
+                      (
                       {(
                         calculationResult.calculatedFoodDropRate *
                         100
                       ).toFixed(1)}
-                      %
-                    </div>
-                    <div className="font-bold text-orange-600 dark:text-orange-400">
-                      {calculationResult.foodHelpsPerDay.toFixed(
-                        1
-                      )}
-                      回/日
-                    </div>
+                      %)
+                    </span>
                   </div>
                 </td>
-                <td className="px-2 md:px-3 py-2 whitespace-nowrap">
-                  <div className="flex flex-col gap-0.5">
-                    <div className="font-bold text-foreground">
+                <td className="px-2 md:px-3 py-1.5 whitespace-nowrap">
+                  <div className="font-bold text-purple-600 dark:text-purple-400">
+                    {calculationResult.skillTriggersPerDay.toFixed(1)}
+                    回/日{" "}
+                    <span className="text-foreground">
+                      (
                       {(
                         calculationResult.calculatedSkillRate *
                         100
                       ).toFixed(1)}
-                      %
-                    </div>
-                    <div className="font-bold text-purple-600 dark:text-purple-400">
-                      {calculationResult.skillTriggersPerDay.toFixed(
-                        1
-                      )}
-                      回/日
-                    </div>
+                      %)
+                    </span>
                   </div>
                 </td>
-                <td className="px-2 md:px-3 py-2 whitespace-nowrap">
+                <td className="px-2 md:px-3 py-1.5 whitespace-nowrap">
                   <div className="flex flex-col gap-0.5">
-                    <div className="font-bold text-foreground">
-                      {(
-                        (1 - calculationResult.calculatedFoodDropRate) *
-                        100
-                      ).toFixed(1)}
-                      %
-                    </div>
                     <div className="font-bold text-green-600 dark:text-green-400">
-                      {calculationResult.berryHelpsPerDay.toFixed(
-                        1
-                      )}
-                      回/日
+                      {calculationResult.berryHelpsPerDay.toFixed(1)}
+                      回/日{" "}
+                      <span className="text-foreground">
+                        (
+                        {(
+                          (1 - calculationResult.calculatedFoodDropRate) *
+                          100
+                        ).toFixed(1)}
+                        %)
+                      </span>
                     </div>
                     <div className="font-bold text-blue-600 dark:text-blue-400">
                       {calculationResult.berryEnergyPerDay.toLocaleString()}

--- a/src/components/HistoryItem.tsx
+++ b/src/components/HistoryItem.tsx
@@ -205,26 +205,17 @@ export default function HistoryItem({
             <table className="w-full text-[10px]">
               <thead className="bg-muted/50">
                 <tr>
-                  <th className="px-2 py-1 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                  <th className="px-2 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
                     お手伝い時間
                   </th>
-                  <th className="px-2 py-1 text-left font-semibold text-muted-foreground whitespace-nowrap">
-                    食材確率
+                  <th className="px-2 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                    食材
                   </th>
-                  <th className="px-2 py-1 text-left font-semibold text-muted-foreground whitespace-nowrap">
-                    食材/日
+                  <th className="px-2 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                    スキル
                   </th>
-                  <th className="px-2 py-1 text-left font-semibold text-muted-foreground whitespace-nowrap">
-                    スキル確率
-                  </th>
-                  <th className="px-2 py-1 text-left font-semibold text-muted-foreground whitespace-nowrap">
-                    スキル/日
-                  </th>
-                  <th className="px-2 py-1 text-left font-semibold text-muted-foreground whitespace-nowrap">
-                    きのみ/日
-                  </th>
-                  <th className="px-2 py-1 text-left font-semibold text-muted-foreground whitespace-nowrap">
-                    きのみE/日
+                  <th className="px-2 py-1.5 text-left font-semibold text-muted-foreground whitespace-nowrap">
+                    きのみ
                   </th>
                 </tr>
               </thead>
@@ -234,29 +225,53 @@ export default function HistoryItem({
                     {item.calculationResult.calculatedSupportTime.toLocaleString()}
                     秒
                   </td>
-                  <td className="px-2 py-1.5 font-bold text-foreground whitespace-nowrap">
-                    {(
-                      item.calculationResult.calculatedFoodDropRate * 100
-                    ).toFixed(1)}
-                    %
+                  <td className="px-2 py-1.5 whitespace-nowrap">
+                    <div className="font-bold text-orange-600 dark:text-orange-400">
+                      {item.calculationResult.foodHelpsPerDay.toFixed(1)}
+                      回/日{" "}
+                      <span className="text-foreground">
+                        (
+                        {(
+                          item.calculationResult.calculatedFoodDropRate *
+                          100
+                        ).toFixed(1)}
+                        %)
+                      </span>
+                    </div>
                   </td>
-                  <td className="px-2 py-1.5 font-bold text-orange-600 dark:text-orange-400 whitespace-nowrap">
-                    {item.calculationResult.foodHelpsPerDay.toFixed(1)}回
+                  <td className="px-2 py-1.5 whitespace-nowrap">
+                    <div className="font-bold text-purple-600 dark:text-purple-400">
+                      {item.calculationResult.skillTriggersPerDay.toFixed(1)}
+                      回/日{" "}
+                      <span className="text-foreground">
+                        (
+                        {(
+                          item.calculationResult.calculatedSkillRate *
+                          100
+                        ).toFixed(1)}
+                        %)
+                      </span>
+                    </div>
                   </td>
-                  <td className="px-2 py-1.5 font-bold text-foreground whitespace-nowrap">
-                    {(
-                      item.calculationResult.calculatedSkillRate * 100
-                    ).toFixed(1)}
-                    %
-                  </td>
-                  <td className="px-2 py-1.5 font-bold text-purple-600 dark:text-purple-400 whitespace-nowrap">
-                    {item.calculationResult.skillTriggersPerDay.toFixed(1)}回
-                  </td>
-                  <td className="px-2 py-1.5 font-bold text-green-600 dark:text-green-400 whitespace-nowrap">
-                    {item.calculationResult.berryHelpsPerDay.toFixed(1)}回
-                  </td>
-                  <td className="px-2 py-1.5 font-bold text-blue-600 dark:text-blue-400 whitespace-nowrap">
-                    {item.calculationResult.berryEnergyPerDay.toLocaleString()}
+                  <td className="px-2 py-1.5 whitespace-nowrap">
+                    <div className="flex flex-col gap-0.5">
+                      <div className="font-bold text-green-600 dark:text-green-400">
+                        {item.calculationResult.berryHelpsPerDay.toFixed(1)}
+                        回/日{" "}
+                        <span className="text-foreground">
+                          (
+                          {(
+                            (1 - item.calculationResult.calculatedFoodDropRate) *
+                            100
+                          ).toFixed(1)}
+                          %)
+                        </span>
+                      </div>
+                      <div className="font-bold text-blue-600 dark:text-blue-400">
+                        {item.calculationResult.berryEnergyPerDay.toLocaleString()}
+                        E/日
+                      </div>
+                    </div>
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
Changed the calculation results table from 7 horizontal columns to 4 compact columns by stacking related data vertically:
- Helper time (お手伝い時間): remains as single column
- Ingredients (食材): stacks probability and count/day vertically
- Skills (スキル): stacks probability and count/day vertically
- Berries (きのみ): stacks count/day and energy/day vertically

This reduces the horizontal width of the table while maintaining all information in a more organized layout.

Fixes #97