### PR TITLE
Fix help time display to show minutes instead of seconds

### DIFF
--- a/src/components/CalculatedPokemonInfo.tsx
+++ b/src/components/CalculatedPokemonInfo.tsx
@@ -159,8 +159,8 @@ const CalculatedPokemonInfo: React.FC<
             <tbody>
               <tr>
                 <td className="px-2 md:px-3 py-1.5 font-bold text-foreground whitespace-nowrap">
-                  {calculationResult.calculatedSupportTime.toLocaleString()}
-                  秒
+                  {(calculationResult.calculatedSupportTime / 60).toFixed(1)}
+                  分
                 </td>
                 <td className="px-2 md:px-3 py-1.5 whitespace-nowrap">
                   <div className="font-bold text-orange-600 dark:text-orange-400">

--- a/src/components/HistoryItem.tsx
+++ b/src/components/HistoryItem.tsx
@@ -222,8 +222,8 @@ export default function HistoryItem({
               <tbody>
                 <tr>
                   <td className="px-2 py-1.5 font-bold text-foreground whitespace-nowrap">
-                    {item.calculationResult.calculatedSupportTime.toLocaleString()}
-                    秒
+                    {(item.calculationResult.calculatedSupportTime / 60).toFixed(1)}
+                    分
                   </td>
                   <td className="px-2 py-1.5 whitespace-nowrap">
                     <div className="font-bold text-orange-600 dark:text-orange-400">


### PR DESCRIPTION
Updated the display format for help time (おてつだい時間) in both:
- Calculation results table (CalculatedPokemonInfo.tsx)
- Historical evaluation record table (HistoryItem.tsx)

The time is now displayed in minutes (分) with 1 decimal place instead of seconds (秒).

Fixes #112