### PR TITLE
Fix Pokemon IV comparison calculation bug

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -30,8 +30,8 @@ export function ThemeToggle() {
       className="h-9 w-9 text-primary-foreground hover:bg-primary-foreground/10"
       aria-label="テーマを切り替え"
     >
-      <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-      <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <Moon className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Sun className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
       <span className="sr-only">テーマを切り替え</span>
     </Button>
   );


### PR DESCRIPTION
- Show moon icon in light mode (to indicate switch to dark)
- Show sun icon in dark mode (to indicate switch to light)
- Follows standard UX convention of showing the mode you'll switch to

Fixes #116