### PR TITLE
fix: Replace img tag with Next.js Image component to resolve lint warning

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
+        pathname: "/PokeAPI/sprites/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/components/PokemonImage.tsx
+++ b/src/components/PokemonImage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import Image from "next/image";
 import { fetchPokemonImage } from "@/services/pokeApi";
 
 interface PokemonImageProps {
@@ -83,11 +84,12 @@ export default function PokemonImage({
 
   // 画像を表示
   return (
-    <img
+    <Image
       src={imageUrl}
       alt={`Pokemon #${pokemonNumber}`}
+      width={size}
+      height={size}
       className={`object-contain ${className}`}
-      style={{ width: size, height: size }}
       loading="lazy"
     />
   );


### PR DESCRIPTION
- Updated PokemonImage component to use Next.js Image component
- Configured next.config.ts to allow external images from PokeAPI's GitHub CDN
- This improves LCP performance and reduces bandwidth usage