### PR TITLE
feat: Add level selection component with sub-skill filtering

### DIFF
--- a/src/components/CombinationRanking.tsx
+++ b/src/components/CombinationRanking.tsx
@@ -21,12 +21,14 @@ interface CombinationRankingProps {
   pokemon: Pokemon;
   currentNature?: string;
   currentSubSkills: SelectedSubSkill[];
+  level?: number;
 }
 
 export default function CombinationRanking({
   pokemon,
   currentNature,
   currentSubSkills,
+  level = 60,
 }: CombinationRankingProps) {
   // Determine initial ranking type based on Pokemon specialty
   const getInitialRankingType = (pokemon: Pokemon): RankingType => {
@@ -57,8 +59,8 @@ export default function CombinationRanking({
 
   // Generate ranking data (memoized)
   const rankingData = useMemo(() => {
-    return generateRankingData(pokemon);
-  }, [pokemon]);
+    return generateRankingData(pokemon, level);
+  }, [pokemon, level]);
 
   // Track generation completion (deferred to avoid cascading renders)
   useEffect(() => {
@@ -74,9 +76,10 @@ export default function CombinationRanking({
       pokemon,
       currentNature,
       currentSubSkills,
-      "skill"
+      "skill",
+      level
     );
-  }, [rankingData.skillRanking, pokemon, currentNature, currentSubSkills]);
+  }, [rankingData.skillRanking, pokemon, currentNature, currentSubSkills, level]);
 
   const ingredientRankingWithUser = useMemo(() => {
     return ensureUserRankInRanking(
@@ -84,9 +87,10 @@ export default function CombinationRanking({
       pokemon,
       currentNature,
       currentSubSkills,
-      "ingredient"
+      "ingredient",
+      level
     );
-  }, [rankingData.ingredientRanking, pokemon, currentNature, currentSubSkills]);
+  }, [rankingData.ingredientRanking, pokemon, currentNature, currentSubSkills, level]);
 
   const berryRankingWithUser = useMemo(() => {
     return ensureUserRankInRanking(
@@ -94,9 +98,10 @@ export default function CombinationRanking({
       pokemon,
       currentNature,
       currentSubSkills,
-      "berry"
+      "berry",
+      level
     );
-  }, [rankingData.berryRanking, pokemon, currentNature, currentSubSkills]);
+  }, [rankingData.berryRanking, pokemon, currentNature, currentSubSkills, level]);
 
   // Get current ranking based on active tab
   const currentRanking = useMemo(() => {

--- a/src/components/LevelSelector.tsx
+++ b/src/components/LevelSelector.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface LevelSelectorProps {
+  /** 選択されたレベル */
+  value: number;
+  /** レベル変更時のコールバック */
+  onChange: (level: number) => void;
+  /** カスタムクラス名 */
+  className?: string;
+}
+
+const QUICK_SELECT_LEVELS = [10, 25, 30, 50, 60];
+
+/**
+ * レベル選択UIコンポーネント
+ * クイック選択ボタンと手動入力の両方をサポート
+ */
+export default function LevelSelector({
+  value,
+  onChange,
+  className = "",
+}: LevelSelectorProps) {
+  const [inputValue, setInputValue] = React.useState(value.toString());
+
+  // value が外部から変更された場合、inputValue も同期
+  React.useEffect(() => {
+    setInputValue(value.toString());
+  }, [value]);
+
+  const handleQuickSelect = (level: number) => {
+    onChange(level);
+    setInputValue(level.toString());
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setInputValue(val);
+
+    // 数値に変換して検証
+    const numValue = parseInt(val, 10);
+    if (!isNaN(numValue) && numValue >= 1 && numValue <= 100) {
+      onChange(numValue);
+    }
+  };
+
+  const handleInputBlur = () => {
+    // ブラー時に値を検証して修正
+    const numValue = parseInt(inputValue, 10);
+    if (isNaN(numValue) || numValue < 1) {
+      onChange(1);
+      setInputValue("1");
+    } else if (numValue > 100) {
+      onChange(100);
+      setInputValue("100");
+    } else {
+      setInputValue(numValue.toString());
+    }
+  };
+
+  return (
+    <div className={`w-full max-w-md mx-auto ${className}`}>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-base">レベル</h2>
+      </div>
+
+      {/* クイック選択ボタン */}
+      <div className="flex gap-2 mb-3 justify-center flex-wrap">
+        {QUICK_SELECT_LEVELS.map((level) => (
+          <Button
+            key={level}
+            variant={value === level ? "default" : "outline"}
+            size="sm"
+            onClick={() => handleQuickSelect(level)}
+            className={`
+              px-4 py-1.5 text-sm font-medium transition-all
+              ${value === level ? "ring-2 ring-offset-2 ring-primary" : ""}
+            `}
+          >
+            Lv.{level}
+          </Button>
+        ))}
+      </div>
+
+      {/* 手動入力 */}
+      <div className="flex items-center gap-2">
+        <label htmlFor="level-input" className="text-sm text-muted-foreground whitespace-nowrap">
+          手動入力:
+        </label>
+        <Input
+          id="level-input"
+          type="number"
+          min="1"
+          max="100"
+          value={inputValue}
+          onChange={handleInputChange}
+          onBlur={handleInputBlur}
+          className="text-center font-medium"
+          placeholder="1-100"
+        />
+      </div>
+
+      {/* 補足説明 */}
+      <div className="mt-2 text-xs text-muted-foreground text-center">
+        レベル1〜100を選択できます
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/types/calculationHistory.ts
+++ b/src/types/calculationHistory.ts
@@ -29,6 +29,9 @@ export interface CalculationHistoryItem {
   /** 性格（表示用テキスト） */
   natureDisplay?: string;
 
+  /** レベル */
+  level: number;
+
   /** 選択されたサブスキル */
   subSkills: SelectedSubSkill[];
 

--- a/src/utils/rankingGenerator.ts
+++ b/src/utils/rankingGenerator.ts
@@ -124,7 +124,8 @@ function generateCombinations(
  * Generate ranking data for all nature and sub-skill combinations
  */
 export function generateRankingData(
-  pokemon: Pokemon
+  pokemon: Pokemon,
+  level: number = 60
 ): {
   skillRanking: RankingEntry[];
   ingredientRanking: RankingEntry[];
@@ -144,7 +145,7 @@ export function generateRankingData(
     for (const subSkills of skillSubSkillCombos) {
       const result = calculatePokemonStatsSimple(
         pokemon,
-        60,
+        level,
         nature.name,
         subSkills
       );
@@ -171,7 +172,7 @@ export function generateRankingData(
     for (const subSkills of ingredientSubSkillCombos) {
       const result = calculatePokemonStatsSimple(
         pokemon,
-        60,
+        level,
         nature.name,
         subSkills
       );
@@ -198,7 +199,7 @@ export function generateRankingData(
     for (const subSkills of berrySubSkillCombos) {
       const result = calculatePokemonStatsSimple(
         pokemon,
-        60,
+        level,
         nature.name,
         subSkills
       );
@@ -287,7 +288,8 @@ export function ensureUserRankInRanking(
   pokemon: Pokemon,
   natureName: string | undefined,
   subSkills: SelectedSubSkill[],
-  rankingType: "skill" | "ingredient" | "berry"
+  rankingType: "skill" | "ingredient" | "berry",
+  level: number = 60
 ): RankingEntry[] {
   // Default to "すなお" (neutral nature) if no nature is selected
   const effectiveNature = natureName || "すなお";
@@ -301,7 +303,7 @@ export function ensureUserRankInRanking(
   // Calculate score for user's combination
   const result = calculatePokemonStatsSimple(
     pokemon,
-    60,
+    level,
     effectiveNature,
     subSkills
   );

--- a/src/utils/subSkillUtils.ts
+++ b/src/utils/subSkillUtils.ts
@@ -124,3 +124,25 @@ export const getRarityStyles = (rarity: Rarity) => {
 
   return styles[rarity];
 };
+
+/**
+ * レベルに基づいてサブスキルをフィルタリング
+ * レベル1-9: サブスキルなし
+ * レベル10-24: 最初のサブスキルのみ
+ * レベル25-49: 最初と2番目のサブスキル
+ * レベル50-100: 3つのサブスキルすべて
+ */
+export const filterSubSkillsByLevel = <T>(
+  subSkills: T[],
+  level: number
+): T[] => {
+  if (level < 10) {
+    return [];
+  } else if (level < 25) {
+    return subSkills.slice(0, 1);
+  } else if (level < 50) {
+    return subSkills.slice(0, 2);
+  } else {
+    return subSkills.slice(0, 3);
+  }
+};


### PR DESCRIPTION
Implements issue #124 requirements:
- Add level selection component with quick select buttons (10, 25, 30, 50, 60)
- Add manual input for levels 1-100
- Default level set to 60
- Implement sub-skill filtering based on level ranges:
  - Levels 1-9: No sub-skills
  - Levels 10-24: First sub-skill only
  - Levels 25-49: First and second sub-skills
  - Levels 50-100: All three sub-skills
- Update calculations for help time, ingredients, skills, and berries based on selected level
- Update ranking generation to use selected level
- Add level to calculation history

Components added:
- src/components/LevelSelector.tsx: Level selection UI component
- src/components/ui/input.tsx: Base input component

Files modified:
- src/components/Search.tsx: Integrate level selector and filter sub-skills
- src/components/CombinationRanking.tsx: Support level parameter
- src/utils/rankingGenerator.ts: Update to use level parameter
- src/utils/subSkillUtils.ts: Add filterSubSkillsByLevel utility
- src/types/calculationHistory.ts: Add level field