### PR TITLE
Fix #136: Add explicit Google verification meta tag in head section

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -105,6 +105,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja" suppressHydrationWarning>
+      <head>
+        <meta name="google-site-verification" content="c6ae21711c3cd1fd" />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >


### PR DESCRIPTION
- Add explicit <head> section with Google Search Console verification meta tag
- Ensures meta tag is placed in <head> before <body> as required by Google
- Resolves Next.js 16 issue where Metadata API may render tags in body instead of head
- Keeps Metadata API verification config for compatibility